### PR TITLE
Add support for px unit stripping.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,10 @@ const defaults = {
 module.exports = postcss.plugin('postcss-pr', (opts = defaults) => {
   return (css) => {
     const rootFontSize = getRootSize(css, opts) || opts.fontSize;
-    const prReg = new RegExp('\\d*\\.?\\d+' + opts.unit, 'gi');
+    const prReg = new RegExp('\\(?\\d*\\.?\\d+(px)?\\)?' + opts.unit, 'gi');
 
     css.replaceValues(prReg, {fast: opts.unit}, (val) => {
-      return pxToRem(parseFloat(val), rootFontSize);
+      return pxToRem(parseFloat(val.replace(/[()px]/gi,'')), rootFontSize);
     });
   };
 });

--- a/test/fixtures/test3.css
+++ b/test/fixtures/test3.css
@@ -1,0 +1,9 @@
+:root {
+  font: 16px / 1.5 "Helvetica", "Arial", sans-serif;
+}
+
+p {
+  margin-top: (24px)pr;
+  margin-bottom: (24px)pr;
+  line-height: (24px)pr;
+}

--- a/test/fixtures/test3.expected.css
+++ b/test/fixtures/test3.expected.css
@@ -1,0 +1,9 @@
+:root {
+  font: 16px / 1.5 "Helvetica", "Arial", sans-serif;
+}
+
+p {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.5rem;
+}

--- a/test/fixtures/test4.css
+++ b/test/fixtures/test4.css
@@ -1,0 +1,10 @@
+:root { font: 14px/1.64286 Arial; }
+p { 
+	margin: (23px)pr auto; 
+	line-height: (23px)pr;
+}
+ul { 
+	margin-top: 23px; 
+	margin-bottom: 23px;
+}
+li { font-size: 18pr; }

--- a/test/fixtures/test4.expected.css
+++ b/test/fixtures/test4.expected.css
@@ -1,0 +1,10 @@
+:root { font: 14px/1.64286 Arial; }
+p { 
+	margin: 1.64286rem auto; 
+	line-height: 1.64286rem;
+}
+ul { 
+	margin-top: 23px; 
+	margin-bottom: 23px;
+}
+li { font-size: 1.28571rem; }

--- a/test/index.js
+++ b/test/index.js
@@ -25,5 +25,15 @@ test('units', (t) => {
     expected('test2'),
     'should be transformed with a font-size declaration');
 
+  t.equal(
+    actual('test3'),
+    expected('test3'),
+    'should strip opening/closing parentheses and px unit');
+	
+  t.equal(
+    actual('test4'),
+    expected('test4'),
+    'should strip opening/closing parentheses and "px" unit only from values that are appended with "pr"');
+
   t.end();
 });


### PR DESCRIPTION
I ran into an issue using postcss-pr along with
postcss-vertical-rhythm. The latter outputs px units,
but the former expects a float value without a unit. This
change allows for the use of postcss-vertical-rhythm's property
value syntax, such as "1vr", to be combined with the "pr"
unit - e.g., margin: (1vr)pr - and successfully
output into the "rem" equivalent.

I noticed after the fact that you also created postcss-lh for a rem-equivalent vertical rhythm solution. I tried out postcss-lh in my project, but I think I prefer the combo of postcss-pr with postcss-vertical-rhythm a little better.